### PR TITLE
Update GetRandomElementUnit.cs

### DIFF
--- a/Runtime/Fundamentals/Units/Collections/GetRandomElementUnit.cs
+++ b/Runtime/Fundamentals/Units/Collections/GetRandomElementUnit.cs
@@ -52,7 +52,7 @@ namespace Bolt.Addons.Community.Fundamentals.Units.Collections
         public bool Dictionary;
 
 
-        private static UnityEngine.Random rand = new UnityEngine.Random();
+        
 
 
         protected override void Definition()


### PR DESCRIPTION
Removing call to UnityEngine.Random because Unity 2020.2 complains about the class being static
Also it seems the variable wasn't used anyway.

Locally this tiny change enabled my project to run after upgrading from 2020.1